### PR TITLE
Update node from 12 to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,5 +31,5 @@ inputs:
         required: false
         default: ','
 runs:
-    using: 'node12'
+    using: 'node16'
     main: 'dist/index.js'


### PR DESCRIPTION
Bump to node16 to avoid github warning, as node12 is deprecated and node16 is forced to be used anyway.